### PR TITLE
Allow for credentials to be read from secret mount

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Docker image to setup feature toggles used via FF4J feature-toggle-api (https://
 
 ## Building
 
+Dockerhub (https://cloud.docker.com/u/hmcts/repository/docker/hmcts/feature-toggle-importer) is deprecated - please use ACR.
+
 Any commit or merge into master will automatically trigger an Azure ACR task. This task has been manually
 created using `./bin/deploy-acr-task.sh`. The task is defined in `acr-build-task.yaml`. 
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Docker image to setup feature toggles used via FF4J feature-toggle-api (https://
 
 2 scripts available to use as you see fit:
 ```
-/scripts/add-weighted-toggle.sh TOGGLE_NAME TOGGLE_DESCRIPTION TOGGLE_WEIGHT ADMIN_USER ADMIN_PASSWORD
-/scripts/add-toggle.sh TOGGLE_NAME TOGGLE_DESCRIPTION TOGGLE_ENABLED ADMIN_USER ADMIN_PASSWORD
+/scripts/add-weighted-toggle.sh TOGGLE_NAME TOGGLE_DESCRIPTION TOGGLE_WEIGHT
+/scripts/add-toggle.sh TOGGLE_NAME TOGGLE_DESCRIPTION TOGGLE_ENABLED
 ```
 
 Note: for `add-weighted-toggle` you can set permissions with environment variable: `PERMISSIONS`
@@ -17,9 +17,11 @@ docker-compose.yaml snippet:
     feature-toggle-importer:
       image: hmcts/feature-toggle-importer
       command: >
-        sh -c "/scripts/add-weighted-toggle.sh cmc_admissions 'CMC admissions' '1.0' admin@example.com Password12 &&
-               /scripts/add-toggle.sh cmc_defence_reminders 'CMC defence reminders' false admin@example.com Password12"
+        sh -c "/scripts/add-weighted-toggle.sh cmc_admissions 'CMC admissions' '1.0' &&
+               /scripts/add-toggle.sh cmc_defence_reminders 'CMC defence reminders' false"
       environment:
         PERMISSIONS: cmc-new-features-consent-given
         FEATURE_TOGGLE_API_URL: http://feature-toggle-api:8580/api/ff4j/store/features/
+        ADMIN_USERNAME: admin@example.com
+        ADMIN_PASSWORD: Password12
 ```

--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 Docker image to setup feature toggles used via FF4J feature-toggle-api (https://github.com/hmcts/feature-toggle-api). 
 
+## Building
+
+Any commit or merge into master will automatically trigger an Azure ACR task. This task has been manually
+created using `./bin/deploy-acr-task.sh`. The task is defined in `acr-build-task.yaml`. 
+
+Note: you will need a GitHub personal token defined in `GITHUB_TOKEN` environment variable to run deploy script (https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line). The token is for setting up a webhook so Azure will be notified when a merge or commit happens. Make sure you are a repo admin and select token scope of: `admin:repo_hook  Full control of repository hooks`
+
+More info on ACR tasks can be read here: https://docs.microsoft.com/en-us/azure/container-registry/container-registry-tasks-overview
+
 2 scripts available to use as you see fit:
 ```
 /scripts/add-weighted-toggle.sh TOGGLE_NAME TOGGLE_DESCRIPTION TOGGLE_WEIGHT

--- a/acr-build-task.yaml
+++ b/acr-build-task.yaml
@@ -1,0 +1,15 @@
+version: 1.0-preview-1
+steps:
+
+  - id: build
+    build: >
+      -t {{.Run.Registry}}/hmcts/feature-toggle-importer:latest -t {{.Run.Registry}}/hmcts/feature-toggle-importer:{{.Run.ID}}
+      .
+    keep: true
+
+  - id: push
+    push:
+      - "{{.Run.Registry}}/hmcts/feature-toggle-importer:{{.Run.ID}}"
+      - "{{.Run.Registry}}/hmcts/feature-toggle-importer:latest"
+    when:
+      - build

--- a/bin/deploy-acr-task.sh
+++ b/bin/deploy-acr-task.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+az account set --subscription DCD-CNP-DEV
+az acr task create \
+    --registry hmcts \
+    --name task-feature-toggle-importer \
+    --file acr-build-task.yaml \
+    --context https://github.com/hmcts/feature-toggle-importer.git \
+    --branch master \
+    --git-access-token $GITHUB_TOKEN

--- a/scripts/add-toggle.sh
+++ b/scripts/add-toggle.sh
@@ -9,8 +9,12 @@ export JSON_DIR="/scripts/"
 export TOGGLE_NAME="${1}"
 export DESCRIPTION="${2}"
 export TOGGLE_ENABLED="${3}"
-export ADMIN_USER="${4}"
-export ADMIN_PW="${5}"
+
+if [ "_${IMPORTER_CREDS_MOUNT}" != "_" ]; then
+  echo "Getting credentials from vault"
+  ADMIN_USERNAME=$(cat ${IMPORTER_CREDS_MOUNT}/admin-username-cmc)
+  ADMIN_PASSWORD=$(cat ${IMPORTER_CREDS_MOUNT}/admin-password-cmc)
+fi
 
 echo -e "VERBOSE=${VERBOSE} ::: JSON_DIR=${JSON_DIR}"
 echo -e "${FEATURE_TOGGLE_API_URL} ::: setting ${TOGGLE_NAME} to ${TOGGLE_ENABLED}"
@@ -19,6 +23,6 @@ envsubst < "${JSON_DIR}"toggle.template.json > "${JSON_DIR}""${TOGGLE_NAME}".jso
 
 curl ${CURL_OPTS} -X PUT \
   -H 'Content-Type: application/json' \
-  -u "${ADMIN_USER}":"${ADMIN_PW}" \
+  -u "${ADMIN_USERNAME}":"${ADMIN_PASSWORD}" \
   -d @"${JSON_DIR}""${TOGGLE_NAME}".json \
   "${FEATURE_TOGGLE_API_URL}""${TOGGLE_NAME}"

--- a/scripts/add-weighted-toggle.sh
+++ b/scripts/add-weighted-toggle.sh
@@ -9,8 +9,12 @@ export JSON_DIR="/scripts/"
 export WEIGHTED_TOGGLE_NAME="${1}"
 export DESCRIPTION="${2}"
 export WEIGHT="${3}"
-export ADMIN_USER="${4}"
-export ADMIN_PW="${5}"
+
+if [ "_${IMPORTER_CREDS_MOUNT}" != "_" ]; then
+  echo "Getting credentials from vault"
+  ADMIN_USERNAME=$(cat ${IMPORTER_CREDS_MOUNT}/admin-username-cmc)
+  ADMIN_PASSWORD=$(cat ${IMPORTER_CREDS_MOUNT}/admin-password-cmc)
+fi
 
 echo -e "VERBOSE=${VERBOSE} ::: JSON_DIR=${JSON_DIR}"
 echo -e "${FEATURE_TOGGLE_API_URL} ::: adding ${WEIGHTED_TOGGLE_NAME} with weight ${WEIGHT} and ${DESCRIPTION}"
@@ -19,6 +23,6 @@ envsubst < "${JSON_DIR}"weighted_toggle.template.json > "${JSON_DIR}""${WEIGHTED
 
 curl ${CURL_OPTS} -X PUT \
   -H 'Content-Type: application/json' \
-  -u "${ADMIN_USER}":"${ADMIN_PW}" \
+  -u "${ADMIN_USERNAME}":"${ADMIN_PASSWORD}" \
   -d @"${JSON_DIR}""${WEIGHTED_TOGGLE_NAME}".json \
   "${FEATURE_TOGGLE_API_URL}""${WEIGHTED_TOGGLE_NAME}"


### PR DESCRIPTION

### Change description ###

Refactoring into a better pattern to allow for secrets to be read from keyvault. As in: https://github.com/hmcts/ccd-docker-definition-importer

Currently using - dont't want to have to use username and password in values: 

```
  rpe-feature-toggle-api:
    releaseNameOverride: ${SERVICE_NAME}-ftr-tgl-api
    importer:
      oneoff:
        command: /scripts/add-weighted-toggle.sh cmc_admissions 'CMC admissions' '1.0' ${ADMIN_USERNAME_TEST} ${ADMIN_PASSWORD_TEST} &&
          /scripts/add-toggle.sh cmc_defence_reminders 'CMC defence reminders' false ${ADMIN_USERNAME_TEST} ${ADMIN_PASSWORD_TEST}
    java:
      releaseNameOverride: ${SERVICE_NAME}-ftr-tgl-api
      environment:
        FEATURES_DB_HOST: ${SERVICE_NAME}-ccd-postgres
```

**Does this PR introduce a breaking change?** (check one with "x")

```
[x] Yes
[ ] No
```
